### PR TITLE
Actions support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,31 @@
+name: Build image and publish to ghcr.io
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version number"
+
+permissions:
+  packages: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Login to GitHub Packages
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/selbi182/spotifybigpicture:${{ github.event.inputs.version }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM openjdk:11-jdk-slim AS build
+WORKDIR /app
+COPY . /app
+RUN chmod +x /app/gradlew && /app/gradlew bootJar
+
+FROM openjdk:11-jre-slim
+COPY --from=build /app/build/libs/SpotifyBigPicture.jar /app/SpotifyBigPicture.jar
+CMD ["java", "-jar", "/app/SpotifyBigPicture.jar"]


### PR DESCRIPTION
Builds and publishes a Docker to the GitHub Container Registry. Can be run manually by supplying version number.